### PR TITLE
fix missing <fstream> in optix_wrapper.cpp

### DIFF
--- a/render/optixutils/c_src/optix_wrapper.cpp
+++ b/render/optixutils/c_src/optix_wrapper.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include <algorithm>
+#include <fstream>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
 #include <optix.h>


### PR DESCRIPTION
Adding <fstream> to fix the compiling error (tested on Ubuntu 22.04)